### PR TITLE
fix: loading smaller images for tracks

### DIFF
--- a/MusicApp/Models/BrowseItem.swift
+++ b/MusicApp/Models/BrowseItem.swift
@@ -45,8 +45,8 @@ extension BrowseItem {
     init(_ data: Track) {
         self.id = data.id
         self.title = data.name
-        self.subTitle = data.type == .playlistTrack ? (data.artists.first?.name ?? "") : "\(data.trackNumber)"
-        self.image = data.album.images?.imageUrl
+        self.subTitle = data.type == .playlistTrack || data.type == .track ? (data.artists.first?.name ?? "") : "\(data.trackNumber)"
+        self.image = data.album.images?.smallImageUrl
         self.type = data.type
     }
 }

--- a/MusicApp/Models/Shared/Images.swift
+++ b/MusicApp/Models/Shared/Images.swift
@@ -17,14 +17,27 @@ struct Images: Codable, Hashable {
 protocol ImageUrls {
 
     var imageUrl: URL? { get }
+    var smallImageUrl: URL? { get }
     var imageUrlWithDimensions: Images? { get }
 }
 
 extension Array: ImageUrls where Element == Images {
 
+    var imageUrlWithDimensions: Images? { self.first }
+
     var imageUrl: URL? { self.first?.url }
 
-    var imageUrlWithDimensions: Images? {
-        return self.first
+    var smallImageUrl: URL? {
+
+        if let image = self.first(where: {
+
+            guard let width = $0.width else { return false }
+
+            return width < 160
+        }) {
+            return image.url
+        }
+
+        return self.imageUrl
     }
 }

--- a/MusicApp/Modules/Library/LibraryViewController.swift
+++ b/MusicApp/Modules/Library/LibraryViewController.swift
@@ -164,6 +164,11 @@ extension LibraryViewController: UICollectionViewDelegate {
 extension LibraryViewController: LibraryViewModelDelegate {
 
     func didFailLoading(with error: any Error) {
+        print("error: \(error)")
+        guard let data = dataSource?.snapshot(),
+              data.numberOfItems == 0 else {
+            return
+        }
 
         showErrorState(for: error)
     }

--- a/MusicApp/Services/AuthManager/AuthManager.swift
+++ b/MusicApp/Services/AuthManager/AuthManager.swift
@@ -49,7 +49,7 @@ final class AuthManager: AuthManagerProtocol {
     }
 
     public var isSignedIn: Bool {
-        accessToken != nil
+        return accessToken != nil
     }
 
     public var accessToken: String? {

--- a/MusicApp/Services/NetworkManager/Endpoints/UsersSavedAlbums.swift
+++ b/MusicApp/Services/NetworkManager/Endpoints/UsersSavedAlbums.swift
@@ -32,6 +32,7 @@ enum UsersSavedItems: EndpointProtocol {
     }
 
     var httpMethod: HTTPMethod {
+        
         switch self {
         case .saveAlbums:
             .put
@@ -80,6 +81,16 @@ enum UsersSavedItems: EndpointProtocol {
             return nil
         case .saveAlbums(let ids), .removeAlbums(let ids):
             return ["ids": ids ]
+        }
+    }
+
+    var cachePolicy: URLRequest.CachePolicy {
+
+        switch self {
+        case .albums, .playlists, .saveAlbums, .removeAlbums:
+            .useProtocolCachePolicy
+        case .following:
+            .returnCacheDataElseLoad
         }
     }
 }


### PR DESCRIPTION
"/me/following" endpoint is suddenly returning 403 on intermittent calls. Add temporary cache policy to endpoint to avoid errors (this will need to change when artist follow functionality is added)

load small images for tracks to improve performance and cache size